### PR TITLE
docs: fix simple typo, disributed -> distributed

### DIFF
--- a/colors/base.py
+++ b/colors/base.py
@@ -238,7 +238,7 @@ class HexColor(RGBColor):
 
 
 class ColorWheel(object):
-    """ Iterate random colors disributed relatively evenly
+    """ Iterate random colors distributed relatively evenly
     around the color wheel.
 
     >>> from colors import ColorWheel


### PR DESCRIPTION
There is a small typo in colors/base.py.

Should read `distributed` rather than `disributed`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md